### PR TITLE
fix: Set default health check type

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,5 +3,6 @@ applications:
 - name: cfbot
   memory: 256M
   no-route: true
+  health-check-type: process
   services:
   - cfbot


### PR DESCRIPTION
The default health check type for new Bluemix apps is 'port'. This means
that a new deployment of cfbot keeps getting killed because the
healthcheck fails to make a TCP connection.

The advice in the CF docs for the Diego architecture is at
https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#no-route

> "In the Diego architecture, no-route skips creating and binding a route
>  for the app, but does not specify which type of health check to perform.
>  If your app does not listen on a port because it is a worker or a
>  scheduler app, then it does not satisfy the port-based health check and
>  Cloud Foundry marks it as crashed."

The advice is that you should set the health-check type to "process".

Signed-off-by: Dale Lane <dale.lane@uk.ibm.com>